### PR TITLE
Pass options to the jade compiler

### DIFF
--- a/lib/jade-static.js
+++ b/lib/jade-static.js
@@ -58,7 +58,7 @@ module.exports = function(options) {
   }
   return function(req, res, next) {
     var d;
-    d = path.join(options.src, req.url);
+    d = path.join(options.src, req.url.split('?')[0]);
     return fs.lstat(d, function(err, stats) {
       if ((err == null) && stats.isDirectory()) {
         return checkFileAndProcess("" + d + "/index.jade", options.jade, res, next);

--- a/lib/jade-static.js
+++ b/lib/jade-static.js
@@ -7,16 +7,21 @@ fs = require('fs');
 
 jade = require('jade');
 
-readAndSendTemplate = function(d, res, next) {
+readAndSendTemplate = function(d, options, res, next) {
   return fs.readFile(d, 'utf8', function(err, data) {
     var html, template;
     if (err != null) {
       return next();
     }
     try {
-      template = jade.compile(data, {
-        filename: d
-      });
+      if (options == null) {
+        options = {
+          filename: d
+        };
+      } else {
+        options.filename = d;
+      }
+      template = jade.compile(data, options);
       html = template({});
       return res.send(html, {
         'Content-Type': 'text/html'
@@ -28,10 +33,10 @@ readAndSendTemplate = function(d, res, next) {
   });
 };
 
-checkFileAndProcess = function(d, res, next) {
+checkFileAndProcess = function(d, options, res, next) {
   return fs.lstat(d, function(err, stats) {
     if ((err == null) && stats.isFile()) {
-      return readAndSendTemplate(d, res, next);
+      return readAndSendTemplate(d, options, res, next);
     } else {
       return next();
     }
@@ -56,11 +61,11 @@ module.exports = function(options) {
     d = path.join(options.src, req.url);
     return fs.lstat(d, function(err, stats) {
       if ((err == null) && stats.isDirectory()) {
-        return checkFileAndProcess("" + d + "/index.jade", res, next);
+        return checkFileAndProcess("" + d + "/index.jade", options.jade, res, next);
       } else if ((err == null) && stats.isFile() && path.extname(d) === '.jade') {
-        return readAndSendTemplate(d, res, next);
+        return readAndSendTemplate(d, options.jade, res, next);
       } else if ((options.html != null) && path.extname(d) === '.html') {
-        return checkFileAndProcess(d.replace(/html$/, 'jade'), res, next);
+        return checkFileAndProcess(d.replace(/html$/, 'jade'), options.jade, res, next);
       } else {
         return next();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jade-static",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "scripts": {
     "test": "mocha test/*.spec.coffee",
     "pretest": "coffee --bare --output ./lib --compile ./src/*.coffee"
@@ -26,6 +26,10 @@
     {
       "name": "Alex Gorbatchev",
       "url": "http://github.com/alexgorbatchev/"
+    },
+    {
+      "name": "Ronald Jerez",
+      "url": "http://github.com/dlanor15/"
     }
   ],
   "licenses": [

--- a/src/jade-static.coffee
+++ b/src/jade-static.coffee
@@ -3,7 +3,7 @@ fs = require 'fs'
 jade = require 'jade'
 
 
-readAndSendTemplate = (d, res, next) ->
+readAndSendTemplate = (d, options, res, next) ->
 
     # Read the jade file.
     fs.readFile d, 'utf8', (err, data) ->
@@ -13,21 +13,26 @@ readAndSendTemplate = (d, res, next) ->
             return next()
 
         try
-            template = jade.compile data, filename: d
+            unless options?
+                options = filename: d
+            else
+                options.filename = d
+
+            template = jade.compile data, options
             html = template {}
             res.send html, 'Content-Type': 'text/html', 200
         catch err
             next err
 
 
-checkFileAndProcess = (d, res, next) ->
+checkFileAndProcess = (d, options, res, next) ->
 
     # Check if file is exists
     fs.lstat d, (err, stats) ->
 
         # If it exists, then we got ourselves a jade file.
         if not err? and stats.isFile()
-            readAndSendTemplate d, res, next
+            readAndSendTemplate d, options, res, next
         else
             next()
 
@@ -55,15 +60,15 @@ module.exports = (options) ->
             if not err? and stats.isDirectory()
 
                 # If so, check if there is exists a file called index.jade.
-                checkFileAndProcess "#{d}/index.jade", res, next
+                checkFileAndProcess "#{d}/index.jade", options.jade, res, next
 
             else if not err? and stats.isFile() and path.extname(d) is '.jade'
-                readAndSendTemplate d, res, next
+                readAndSendTemplate d, options.jade, res, next
                 
             # try to replace html file by jade template
             else if options.html? and path.extname(d) is '.html'
 
                 # check template exists
-                checkFileAndProcess d.replace(/html$/, 'jade'), res, next
+                checkFileAndProcess d.replace(/html$/, 'jade'), options.jade, res, next
             else
                 next()

--- a/src/jade-static.coffee
+++ b/src/jade-static.coffee
@@ -51,7 +51,7 @@ module.exports = (options) ->
     return (req, res, next) ->
 
         # The inputed url relative to the path.
-        d = path.join options.src, req.url
+        d = path.join options.src, req.url.split('?')[0]
 
         # Determines what d is.
         fs.lstat d, (err, stats) ->

--- a/test/jade-static.spec.coffee
+++ b/test/jade-static.spec.coffee
@@ -1,5 +1,6 @@
 express = require 'express'
 supertest = require 'supertest'
+assert = require 'assert'
 jadeStatic = require '../src/jade-static'
 
 describe 'jade-static', ->
@@ -7,28 +8,38 @@ describe 'jade-static', ->
 
   before ->
     app = express()
-    app.use '/mount', jadeStatic "#{__dirname}/public"
+    src = "#{__dirname}/public"
+    app.use '/mount', jadeStatic src
+    app.use '/pretty', jadeStatic {src, jade: pretty: true}
     request = supertest app
 
   it 'serves index.jade from folder', (done) ->
     request
       .get '/mount'
       .expect 200
-      .expect '<div class="hello">World!</div>', done
+      .expect '<div class="hello"><div class="pretty">World!</div></div>', done
 
   it 'serves index.jade', (done) ->
     request
       .get '/mount/index.jade'
       .expect 200
-      .expect '<div class="hello">World!</div>', done
+      .expect '<div class="hello"><div class="pretty">World!</div></div>', done
 
   it 'serves index.html', (done) ->
     request
       .get '/mount/index.html'
       .expect 200
-      .expect '<div class="hello">World!</div>', done
+      .expect '<div class="hello"><div class="pretty">World!</div></div>', done
 
   it 'handles 404s', (done) ->
     request
       .get '/mount/missing-file.jade'
       .expect 404, done
+
+  it 'passes options to jade compiler', (done) ->
+    request
+      .get '/pretty/index.html'
+      .expect 200
+      .end (err, res) ->
+        assert.ok /\s<\/div>$/.test(res.text), 'Output does not contain whitespace'
+        done()

--- a/test/jade-static.spec.coffee
+++ b/test/jade-static.spec.coffee
@@ -43,3 +43,8 @@ describe 'jade-static', ->
       .end (err, res) ->
         assert.ok /\s<\/div>$/.test(res.text), 'Output does not contain whitespace'
         done()
+
+  it 'ignores query strings', (done) ->
+    request
+      .get '/mount/index.html?foo=bar'
+      .expect 200, done

--- a/test/public/index.jade
+++ b/test/public/index.jade
@@ -1,1 +1,2 @@
-.hello World!
+.hello
+	.pretty World!


### PR DESCRIPTION
- able to pass in an additional option 'jade' with an object of options to pass over to the compiler
- strip any query strings from the URL which results in a 404 even when the requested file exists
